### PR TITLE
fixing incorrect file name

### DIFF
--- a/ee-util.py
+++ b/ee-util.py
@@ -21,7 +21,7 @@ def get_asset_bucket()->str:
 
   raise ValueError('Missing env TEMPLATE_ASSET_BUCKET and S3_ASSET_BUCKET')
 
-with open('cdk.out/DrDeployer.template.json','rt') as f:
+with open('cdk.out/CfnMultiRegionOrchestrator.template.json','rt') as f:
   content = loads(f.read()) #stdin.read())
 
 parameters:dict = content['Parameters']


### PR DESCRIPTION

*Description of changes:*

The generated cfn file from the synth is called CfnMultiRegionOrchestrator.template.json. Updating the event engine util so it can find the file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
